### PR TITLE
Adapting the codim feature 

### DIFF
--- a/tests/test_codim_external_operator.py
+++ b/tests/test_codim_external_operator.py
@@ -76,8 +76,7 @@ def test_external_operator_codim_1(quadrature_degree):
     Qe = basix.ufl.quadrature_element(submesh.basix_cell(), degree=quadrature_degree, value_shape=())
     Q = dolfinx.fem.functionspace(submesh, Qe)
 
-    g = FEMExternalOperator(u, function_space=Q)  # g is now Symbolic not numpy involved
-    g.external_function = g_external
+    g = FEMExternalOperator(u, function_space=Q, external_function=g_external)  # g is now Symbolic not numpy involved
 
     ft = dolfinx.mesh.meshtags(mesh, mesh.topology.dim - 1, ext_facets, np.full_like(ext_facets, 1))
     ds = ufl.Measure(
@@ -93,7 +92,7 @@ def test_external_operator_codim_1(quadrature_degree):
         J_replaced, J_external_operators = replace_external_operators(J)
         J_compiled = dolfinx.fem.form(J_replaced, entity_maps=entity_maps)
         # Pack coefficients for g
-        evaluated_operands = evaluate_operands(J_external_operators, entity_maps=entity_maps)
+        evaluated_operands = evaluate_operands(J_external_operators, entity_maps=entity_maps, function_space=V)
         _ = evaluate_external_operators(J_external_operators, evaluated_operands)
 
         Jh = dolfinx.fem.assemble_scalar(J_compiled)
@@ -113,7 +112,7 @@ def test_external_operator_codim_1(quadrature_degree):
 
 @pytest.mark.parametrize("quadrature_degree", range(1, 5))
 def test_external_operator_codim_0(quadrature_degree):
-    """Test assembly of codim 1 external operator"""
+    """Test assembly of codim 0 external operator"""
 
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 5, 5)
     mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
@@ -138,8 +137,7 @@ def test_external_operator_codim_0(quadrature_degree):
     Qe = basix.ufl.quadrature_element(submesh.basix_cell(), degree=quadrature_degree, value_shape=())
     Q = dolfinx.fem.functionspace(submesh, Qe)
 
-    f = FEMExternalOperator(u, function_space=Q)  # g is now Symbolic not numpy involved
-    f.external_function = f_external
+    f = FEMExternalOperator(u, function_space=Q, external_function=f_external)  # g is now Symbolic not numpy involved
 
     dx = ufl.Measure(
         "dx", domain=mesh, subdomain_data=ct, subdomain_id=1, metadata={"quadrature_degree": quadrature_degree}
@@ -154,7 +152,7 @@ def test_external_operator_codim_0(quadrature_degree):
         J_replaced, J_external_operators = replace_external_operators(J)
         J_compiled = dolfinx.fem.form(J_replaced, entity_maps=entity_maps)
         # Pack coefficients for g
-        evaluated_operands = evaluate_operands(J_external_operators, entity_maps=entity_maps)
+        evaluated_operands = evaluate_operands(J_external_operators, entity_maps=entity_maps, function_space=V)
         _ = evaluate_external_operators(J_external_operators, evaluated_operands)
 
         Jh = dolfinx.fem.assemble_scalar(J_compiled)


### PR DESCRIPTION
The new feature breaks the previous version of `dolfinx-external-operator`. We suppose at the moment that all operands are either `ufl.Expressions` or `fem.Function`, which should be evaluated on the same quadrature space where the original external operator exists.

I added an optional argument, `function_space` to `evaluate_operands` to support both the "standard" examples and the codim ones. It enables to use an arbitrary function space on all operands.

The codim tests are not passed due to inappropriate type of `entity_maps` of the `fem.form` constructor. The error araises here: `J_compiled = dolfinx.fem.form(J_replaced, entity_maps=entity_maps)`
@jorgensd, what version of FEniCSx do you use for these tests?

The PR has been accepted too fast. Sorry!

I will need to write proper pytest-s as @jhale recommended.